### PR TITLE
feat: Add basic dummy service and security constraints

### DIFF
--- a/asm-gateway/sa-istio.yaml
+++ b/asm-gateway/sa-istio.yaml
@@ -1,9 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: my-mesh
+  name: asm-gateway
   labels:
-    istio.io/rev: asm-managed-rapid # Check the revision of the ASM
     istio-injection: enabled
 ---
 

--- a/dummy-service/dummy.yaml
+++ b/dummy-service/dummy.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   name: my-mesh
   labels:
-    istio.io/rev: asm-managed-rapid
     istio-injection: enabled
 ---   
 apiVersion: apps/v1

--- a/dummy-service/pod.yaml
+++ b/dummy-service/pod.yaml
@@ -9,10 +9,12 @@ spec:
   containers:
   - name: simple-pod
     image: nginx:alpine
-    requests:
-      cpu: 250m
-      memory: 256Mi
-    limits:
-      memory: 256Mi
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+      limits:
+        memory: 256Mi
+        cpu: 250m
     ports:
     - containerPort: 80

--- a/dummy-service/pod.yaml
+++ b/dummy-service/pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: simple-pod
+  namespace: my-mesh
+  labels:
+    app: simple-pod
+spec:
+  containers:
+  - name: simple-pod
+    image: nginx:alpine
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      memory: 256Mi
+    ports:
+    - containerPort: 80

--- a/dummy-service/pod.yaml
+++ b/dummy-service/pod.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: simple-pod
-  namespace: my-mesh
   labels:
     app: simple-pod
 spec:

--- a/security/constraint.yaml
+++ b/security/constraint.yaml
@@ -1,7 +1,7 @@
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequiredLabels
 metadata:
-  name: ss-must-have-team-label
+  name: pod-must-have-team-label
 spec:
   match:
     kinds:

--- a/security/constraint.yaml
+++ b/security/constraint.yaml
@@ -1,14 +1,12 @@
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequiredLabels
 metadata:
-  name: namespace-must-have-istio-labels
+  name: ss-must-have-team-label
 spec:
-  enforcementAction: deny
   match:
     kinds:
-      - apiGroups: [""]
-        kinds: ["Namespace"]
+    - apiGroups: [""]
+      kinds: ["Pod"]
   parameters:
     labels:
-      - key: "istio.io/rev"
-      - key: "istio-injection"
+    - key: "team"

--- a/security/istio-mtls-constraint.yaml
+++ b/security/istio-mtls-constraint.yaml
@@ -1,0 +1,13 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredLabels
+metadata:
+  name: namespace-must-have-istio-label
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Namespace"]
+  parameters:
+    labels:
+      - key: "istio-injection"

--- a/utils/curl.yaml
+++ b/utils/curl.yaml
@@ -1,4 +1,11 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-mesh
+  labels:
+    istio-injection: enabled
+---    
+apiVersion: v1
 kind: Pod
 metadata:
   name: curl-test-pod

--- a/utils/curl.yaml
+++ b/utils/curl.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: test
-  labels:
-    istio-injection: enabled
 ---    
 apiVersion: v1
 kind: Pod

--- a/utils/curl.yaml
+++ b/utils/curl.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: my-mesh
+  name: test
   labels:
     istio-injection: enabled
 ---    


### PR DESCRIPTION

This PR introduces a basic dummy service deployment and accompanying security constraints to demonstrate a more complete example of a GKE Service Mesh setup.

**Changes:**

*   **Dummy Service (`dummy-service/`)**:
    *   Added a `Deployment` and `Service` for a simple HTTP server using `nginx:alpine`.
    *   The service is deployed to the `my-mesh` namespace, which is labeled for Istio sidecar injection.
    *   Included `livenessProbe` and `readinessProbe` for health checks.
    *   Added a separated pod definition that does not need to be injected (`pod.yaml`).
*   **Security Constraints (`security/`)**:
    *   Implemented a Gatekeeper constraint (`constraint.yaml`) to enforce that all new `Pod`s must have a `team` label.
    *   Implemented another Gatekeeper constraint (`istio-mtls-constraint.yaml`) to ensure new `Namespace`s are labeled for Istio sidecar injection (`istio-injection: enabled`).
*   **`curl` Test Pod (`utils/curl.yaml`):**
    *   Added a `curl` test Pod in the `test` namespace.
    *   This pod now include the `iputils` install using `initContainer` in order to be able to execute `nslookup` command.
*   **Istio Gateway Service Account:**
    * Added a new `sa-istio.yaml` file to define the ServiceAccount, Role and RoleBinding for Istio ingressgateway.
* **README.md update**:
    * Changed the section testing with `curl-test-pod` in order to be accurate.

**Purpose:**

*   Demonstrates the creation of a basic, mesh-enabled service.
*   Showcases how to use Gatekeeper constraints to enforce security policies within the cluster.
*   Provides a `curl` test pod for easily testing connectivity within the mesh.
*   Illustrates how to set up the necessary resources for istio ingressgateway.
