### PR TITLE
JWT Auth Policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,88 @@
+# Python
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Environments
+.env
+.venv
+env/
+venv/
+
+# MyPy
+.mypy_cache/
+
+# IDE
+.idea/
+.vscode/
+
+# GKE Manifests
+# Ignore common Kubernetes/GKE manifest output files
+*.yaml.bak
+*.yml.bak
+*.yaml.old
+*.yml.old
+*.yaml~
+*.yml~
+*.diff
+*.patch
+
+# Private folder
+private/
+
+# Other
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,16 @@ venv/
 *.diff
 *.patch
 
+# Go
+*.go
+*.go.bak
+*.go~
+bin/
+pkg/
+Godeps/_workspace/
+Godeps/
+vendor/
+
 # Private folder
 private/
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## GKE Gateway and Istio Gateway Integration with mTLS and Gatekeeper Constraint
 
-This repository demonstrates how to integrate GKE Gateway with Istio Gateway to manage ingress traffic in a Google Kubernetes Engine (GKE) cluster, while enforcing strict mTLS within the Istio service mesh. It also includes an optional Gatekeeper constraint to ensure that newly created namespaces are automatically labeled for Istio sidecar injection.
+This repository demonstrates how to integrate GKE Gateway with Istio Gateway to manage ingress traffic in a Google Kubernetes Engine (GKE) cluster, while enforcing strict mTLS within the Istio service mesh. It also includes an optional Gatekeeper constraint to ensure that newly created namespaces are automatically labeled for Istio sidecar injection.  Additionally, it demonstrates JWT authentication for a microservice.
 
 **Key Features**
 
@@ -8,6 +8,7 @@ This repository demonstrates how to integrate GKE Gateway with Istio Gateway to 
 * **Istio Gateway:** Manages internal traffic routing and mTLS within the Istio service mesh.
 * **Strict mTLS:** Enforces mutual TLS authentication between all services within the mesh, enhancing security.
 * **Gatekeeper Constraint (Optional):** Ensures that new namespaces are automatically labeled for Istio sidecar injection, simplifying mesh expansion.
+* **JWT Authentication:**  Secures a microservice (`simple-http-server`) using JSON Web Tokens (JWTs) and Istio's authentication capabilities.
 
 **Components**
 
@@ -17,6 +18,9 @@ This repository demonstrates how to integrate GKE Gateway with Istio Gateway to 
 * **Istio VirtualService:** Routes traffic from the Istio Gateway to specific services.
 * **Gatekeeper ConstraintTemplate and Constraint:** Enforces the required labels for new namespaces.
 * **`curl-test-pod`:** A pod with `curl` installed for testing connectivity to services within the mesh.
+* **`jwt-generator/main.py`:** A Python script to generate JWTs for authentication.
+* **`jwt-auth.yaml`:** Istio configuration for JWT authentication and authorization.
+
 
 **Deployment**
 
@@ -24,18 +28,22 @@ This repository demonstrates how to integrate GKE Gateway with Istio Gateway to 
    * A GKE Enterprise cluster with Cloud Service Mesh enabled
    * A GKE cluster with the Gateway API enabled.
    * Gatekeeper installed (optional).
+   * A Google Cloud Service Account with appropriate permissions (for JWT generation).
 
 2. **Configure and Deploy:**
-   * Modify the provided YAML files to match your environment (e.g., IP addresses, domain names, namespaces).
+   * Modify the provided YAML files to match your environment (e.g., IP addresses, domain names, namespaces).  Pay close attention to the `jwt-auth.yaml` file and ensure the `issuer` and `jwks` values are correct for your service account.
    * Apply the GKE Gateway, Istio Gateway, VirtualService, and any other necessary Istio resources.
+   * Apply the `jwt-auth.yaml` file to enable JWT authentication.
    * If using Gatekeeper, deploy the ConstraintTemplate and Constraint.
    * Deploy the `curl-test-pod` to the `test` namespace.
+   * Run `jwt-generator/main.py` with your service account key file to generate a JWT.  Use this JWT in the `Authorization` header of requests to the `simple-http-server` service.
 
 **Usage**
 
 * **Access your applications through the GKE Gateway's external IP address.**
 * Istio will manage internal traffic routing and enforce mTLS within the mesh.
 * The Gatekeeper constraint (if enabled) will forces labels on new namespaces for Istio sidecar injection.
+* Access the `simple-http-server` service using a JWT for authentication.
 
 **Testing with `curl-test-pod`**
 
@@ -72,7 +80,6 @@ This repository demonstrates how to integrate GKE Gateway with Istio Gateway to 
 
 The included Gatekeeper constraint enforces the following labels on new namespaces:
 
-* `istio.io/rev`: Associates the namespace with a specific revision of Anthos Service Mesh (ASM).
 * `istio-injection`: Enables automatic sidecar injection for services in the namespace.
 
 This ensures that new namespaces are automatically integrated into the Istio service mesh, simplifying management and maintaining consistency.

--- a/dummy-service/dummy-app/Dockerfile
+++ b/dummy-service/dummy-app/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.20
+
+WORKDIR /app
+
+COPY go.mod ./
+RUN go mod download
+
+COPY *.go ./
+
+RUN go build -o main .
+
+CMD ["./main"]

--- a/dummy-service/dummy-app/go.mod
+++ b/dummy-service/dummy-app/go.mod
@@ -1,0 +1,3 @@
+module dummy-app
+
+go 1.20

--- a/dummy-service/dummy.yaml
+++ b/dummy-service/dummy.yaml
@@ -22,25 +22,25 @@ spec:
     spec:
       containers:
       - name: simple-http-server
-        image: nginx:alpine
+        image: us-east4-docker.pkg.dev/db-demo-gke-ent/my-docker/dummy-app:latest
         ports:
-        - containerPort: 80
+        - containerPort: 8080
         resources:
           requests:
-            cpu: 250m
+            cpu: 100m
             memory: 256Mi
           limits:
             memory: 256Mi
         livenessProbe:
-          httpGet:  # Use httpGet instead of tcpSocket
-            path: /
-            port: 80
+          httpGet:
+            path: /health
+            port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10
         readinessProbe:
-          httpGet: # Use httpGet instead of tcpSocket
-            path: /
-            port: 80
+          httpGet:
+            path: /health
+            port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10
       terminationGracePeriodSeconds: 30
@@ -56,5 +56,5 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: ClusterIP

--- a/jwt/jwt-auth.yaml
+++ b/jwt/jwt-auth.yaml
@@ -31,7 +31,7 @@ spec:
         paths: ["/jwt-val"] # Rule for /jwt-validatiobn JWT check
     when:
     - key: request.auth.principal
-      values: ["*"] #This should be replaced with your actual principal values if you want to restrict to specific users. 
+      values: ["jwt-signer@db-demo-gke-ent.iam.gserviceaccount.com/jwt-signer@db-demo-gke-ent.iam.gserviceaccount.com"] # issuer/sub of the JWT 
   - to:
     - operation:
         # This rule applies to requests whose path is NOT /jwt-val

--- a/jwt/jwt-auth.yaml
+++ b/jwt/jwt-auth.yaml
@@ -1,0 +1,39 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "RequestAuthentication"
+metadata:
+  name: "jwt"
+  namespace: my-mesh
+spec:
+  selector:
+    matchLabels:
+      app: simple-http-server
+  jwtRules:
+  - forwardOriginalToken: true
+    issuer: "jwt-signer@db-demo-gke-ent.iam.gserviceaccount.com"
+    jwks: |
+      { "keys": [{"n": "vfOHxJzTwiamuPu1UHM6SOC5fbbNY_p3PFKiPSyJszINWdy78nNubobsjsnQxUHdntM-R7MhEbDPwAs2tzCnUck5R7jl_1NwszEAUeJCFlqVqWSRGCFoC5x19SAl6r52DV5fQApv7xTSNquNfmXxqykoq7kO_DjfWEtPEyT03bYGHNzwjnjhn_FqJ-K29fT31k7_9LSj2p3Q0bahDOwZiVjAvVF8efVjKT35iZoaKWm0r2qfwwCP4D-gL5wzboyzhyfJjQvYhL7TzTHvsYol403h239l5nAKpUmWDg5MCaiLjcGJT_rIZumI3FPIFRgMbTt4NrVhPzzWqANc9uTH-w","kty": "RSA","alg": "RS256","e": "AQAB","kid": "c3cfed78d6f48dbc961f51440be2336803ec39a7","use": "sig" }]}
+    #jwksUri: "https://www.googleapis.com/service_accounts/v1/jwk/jwt-signer@db-demo-gke-ent.iam.gserviceaccount.com"
+    #jwksUri: "https://www.googleapis.com/robot/v1/metadata/x509/jwt-signer@db-demo-gke-ent.iam.gserviceaccount.com"
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: require-jwt
+  namespace: my-mesh
+spec:
+  selector:
+    matchLabels:
+      app: simple-http-server
+  action: ALLOW
+  rules:
+  - to:
+    - operation:
+        paths: ["/jwt-val"] # Rule for /jwt-validatiobn JWT check
+    when:
+    - key: request.auth.principal
+      values: ["*"] #This should be replaced with your actual principal values if you want to restrict to specific users. 
+  - to:
+    - operation:
+        # This rule applies to requests whose path is NOT /jwt-val
+        notPaths: ["/jwt-val"]   
+     

--- a/jwt/jwt-generator/main.py
+++ b/jwt/jwt-generator/main.py
@@ -1,0 +1,90 @@
+"""
+Generates a JWT (JSON Web Token) using a Google API Service Account and prints it to the terminal.
+"""
+
+import argparse
+import time
+import os
+
+import google.auth.crypt
+import google.auth.jwt
+
+import requests
+
+
+def generate_jwt(
+    sa_keyfile,
+    sa_email,
+    audience,
+    expiry_length,
+):
+    """Generates a signed JSON Web Token using a Google API Service Account."""
+
+    now = int(time.time())
+
+    # build payload
+    payload = {
+        "iat": now,
+        # expires after 'expiry_length' seconds.
+        "exp": now + expiry_length,
+        # iss must match 'issuer' in the security configuration in your
+        # swagger spec (e.g. service account email). It can be any string.
+        "iss":sa_email,
+        # aud must be either your Endpoints service name, or match the value
+        # specified as the 'x-google-audience' in the OpenAPI document.
+        "aud": "https://www.googleapis.com/auth/iam",
+        # sub and email should match the service account's email address
+        "sub": sa_email,
+        "email": sa_email,
+    }
+
+    # sign with keyfile
+    signer = google.auth.crypt.RSASigner.from_service_account_file(sa_keyfile)
+    jwt = google.auth.jwt.encode(signer, payload)
+
+    return jwt
+
+
+def main():
+    """Parses command-line arguments and generates/prints the JWT."""
+    parser = argparse.ArgumentParser(
+        description="Generate a JWT using a Google API Service Account."
+    )
+    parser.add_argument(
+        "--sa_keyfile",
+        required=True,
+        help="Path to the Google API Service Account key file (JSON).",
+    )
+    parser.add_argument(
+        "--sa_email",
+        default="jwt-signer@db-demo-gke-ent.iam.gserviceaccount.com",
+        help="Service account email.",
+    )
+    parser.add_argument(
+        "--audience",
+        default="simple-http-server",
+        help="Audience for the JWT (e.g., your Endpoints service name).",
+    )
+    parser.add_argument(
+        "--expiry_length",
+        type=int,
+        default=1800,
+        help="Expiry length of the JWT in seconds (default: 1800).",
+    )
+
+    args = parser.parse_args()
+
+    # Check if the keyfile exists
+    if not os.path.exists(args.sa_keyfile):
+        print(f"Error: Service account key file not found: {args.sa_keyfile}")
+        return
+
+    jwt = generate_jwt(
+        args.sa_keyfile, args.sa_email, args.audience, args.expiry_length
+    )
+    print("Generated JWT:")
+    print(jwt)
+
+
+if __name__ == "__main__":
+    main()

--- a/jwt/jwt-generator/requirements.txt
+++ b/jwt/jwt-generator/requirements.txt
@@ -1,0 +1,2 @@
+google-auth
+requests


### PR DESCRIPTION
This PR enhances security by adding JWT authentication to the simple-http-server microservice using Istio. The jwt-auth.yaml file configures Istio's authentication and authorization policies to require a valid JWT for access, and a new Python script generates JWTs using a Google Cloud Service Account. The authorization policy is updated to restrict access based on the JWT's subject (sub) claim, improving security.